### PR TITLE
Fix Image Paths

### DIFF
--- a/lidc2dicom.py
+++ b/lidc2dicom.py
@@ -204,7 +204,7 @@ class LIDC2DICOMConverter:
     for scan in scans:
       studyUID = scan.study_instance_uid
       seriesUID = scan.series_instance_uid
-      seriesDir = os.path.join(self.rootDir,s,studyUID,seriesUID)
+      seriesDir = scan.get_path_to_dicom_files()
       if not os.path.exists(seriesDir):
         self.logger.error("Files not found for subject "+s)
         return
@@ -305,7 +305,7 @@ class LIDC2DICOMConverter:
     for scan in scans:
       studyUID = scan.study_instance_uid
       seriesUID = scan.series_instance_uid
-      seriesDir = os.path.join(self.rootDir,s,studyUID,seriesUID)
+      seriesDir = scan.get_path_to_dicom_files()
       if not os.path.exists(seriesDir):
         self.logger.error("Files not found for subject "+s)
         return


### PR DESCRIPTION
This PR fixes/updates the method of determining the input directory to ensure it works with the current form of the LIDC dataset.

I recently tried to run the script with the latest version of pylidc (0.2.2) installed and a recently-downloaded version of the LIDC-IDRI dataset and had a problem with script using incorrect paths to the input image files.

It appears that the script assumes that the image paths appear at 

```
<imagesDir>/<subject_id>/<studyUID>/<seriesUID>
```

but this does not match the directory hierarchy of the dataset downloaded from TCIA. Presumably it did at some point and something changed but I haven't managed to pinpoint the specifics. Currently the downloaded dataset uses what looks like study and series descriptions in the hierarchy rather than UIDs.

In order to fix this I simply set the input image location according to the `scan.get_path_to_dicom_files()` method of pylidc's `Scan` method and I was able to run the script without further problems.